### PR TITLE
Commit RSS feed to repository

### DIFF
--- a/.github/workflows/anthropic-news-rss.yml
+++ b/.github/workflows/anthropic-news-rss.yml
@@ -1,0 +1,60 @@
+name: Generate Anthropic News RSS
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: generate
+        uses: google-gemini/gemini-cli-action@v1
+        with:
+          prompt: |
+            あなたはウェブ情報を収集して整理するAIエージェントです。以下の手順に従ってください。
+            
+            1. https://www.anthropic.com/news をクロールして、ページ内に掲載されているすべてのニュース記事の「タイトル」「日付」「URL」「概要（本文の冒頭または meta description）」を収集してください。
+            
+            2. 各記事について、RSS 2.0 形式の <item> を構成してください。各 <item> には以下の要素を含めてください：
+               - <title>
+                 - 日本語に翻訳したものを設定してください
+               - <link>
+               - <pubDate>
+               - <description>
+                 - 日本語に翻訳したものを設定してください
+            
+            3. すべての <item> をまとめて <channel> 内に収めた、完全な RSS フィード（XML形式）を生成してください。
+            
+            4. RSSの<channel>には以下の情報を設定してください：
+               - <title>: Anthropic News
+               - <link>: https://www.anthropic.com/news
+               - <description>: Anthropic公式サイトのニュースをもとに自動生成された非公式RSSフィードです
+            
+            注意事項：
+            - <pubDate> の形式は RFC-822（例: Mon, 08 Jul 2025 12:00:00 +0000）としてください。
+            - <description> 内には HTML タグを使用せず、プレーンテキストのみを使ってください。
+            - 最後に生成した RSS フィードを XML のコードブロックとして出力してください。
+
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+      - name: Save RSS feed
+        run: |
+          mkdir -p dist
+          echo "${{ steps.generate.outputs.response }}" > dist/anthropic-news.xml
+
+      - name: Commit RSS feed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add dist/anthropic-news.xml
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update RSS feed"
+            git push
+          fi

--- a/dist/anthropic-news.xml
+++ b/dist/anthropic-news.xml
@@ -1,0 +1,1 @@
+This file will be overwritten by the workflow


### PR DESCRIPTION
## Summary
- generate RSS feed using gemini-cli-action
- commit `dist/anthropic-news.xml` back to the repo instead of uploading an artifact

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686f8e5e8b0c832b8b8db6c19a51d26b